### PR TITLE
Prevent "TypeError: expected bytes, str found" error with TLS certs.

### DIFF
--- a/gNMI_Subscribe.py
+++ b/gNMI_Subscribe.py
@@ -208,7 +208,7 @@ if __name__ == '__main__':
     if options.tls or options.cert:
         log.debug("Create SSL Channel")
         if options.cert:
-            cred = grpc.ssl_channel_credentials(root_certificates=open(options.cert).read())
+            cred = grpc.ssl_channel_credentials(root_certificates=open(options.cert).read().encode("us-ascii"))
             opts = []
             if options.altName:
                 opts.append(('grpc.ssl_target_name_override', options.altName,))


### PR DESCRIPTION
Observed with Python 3.6.5 installed via Homebrew on macOS 10.13.4.

